### PR TITLE
Reuse bitmasks between combinations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,5 +41,9 @@ bench = false
 name = "top"
 bench = false
 
+[[bin]]
+name = "reuse_bitmask"
+bench = false
+
 [profile.release]
 debug = true

--- a/src/bin/reuse_bitmask.rs
+++ b/src/bin/reuse_bitmask.rs
@@ -1,0 +1,223 @@
+use corrset::{utils, Question, User};
+use fxhash::FxHashSet;
+use itertools::Itertools;
+use rayon::prelude::*;
+use std::collections::HashMap;
+use std::time::Instant;
+
+fn intersect_into(dst: &mut [u64], src_a: &[u64], src_b: &[u64]) {
+  debug_assert_eq!(dst.len(), src_a.len());
+  debug_assert_eq!(dst.len(), src_b.len());
+  for ((dst, src_a), src_b) in dst.iter_mut().zip(src_a).zip(src_b) {
+    *dst = src_a & src_b
+  }
+}
+
+fn iterate_bits(src: &[u64]) -> BitsIterator {
+  BitsIterator {
+    vec: src,
+    idx: 0,
+    curr: src[0],
+  }
+}
+
+struct BitsIterator<'a> {
+  vec: &'a [u64],
+  idx: usize,
+  curr: u64,
+}
+
+impl<'a> Iterator for BitsIterator<'a> {
+  type Item = usize;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    if self.curr == 0 {
+      if self.idx >= self.vec.len() {
+        return None;
+      }
+
+      match self.vec[(self.idx + 1)..]
+        .iter()
+        .find_position(|v| **v != 0)
+      {
+        None => {
+          self.idx = self.vec.len();
+          return None;
+        }
+        Some((idx, val)) => {
+          self.idx += idx + 1;
+          self.curr = *val;
+        }
+      }
+    }
+
+    let offset = self.curr.trailing_zeros();
+    self.curr ^= 1 << offset;
+    Some(self.idx * 64 + offset as usize)
+  }
+}
+fn main() {
+  let mut args = std::env::args().skip(1);
+
+  let k = match args.next() {
+    Some(k) => k.parse::<usize>().unwrap(),
+    None => 5,
+  };
+  assert_ne!(k, 0);
+
+  let kind = match args.next() {
+    Some(kind) => kind,
+    None => "large".to_string(),
+  };
+
+  let start = Instant::now();
+  let data = corrset::load_rows(format!("data/data-{kind}.json")).unwrap();
+  let read = start.elapsed();
+  println!("Read {} file in {}ms", kind, read.as_millis());
+
+  let start = Instant::now();
+  let (users, questions): (FxHashSet<_>, FxHashSet<_>) =
+    data.iter().map(|row| (&row.user, &row.question)).unzip();
+  let users: Vec<_> = users.into_iter().cloned().collect();
+  let user_lookup: HashMap<&User, usize> = users.iter().enumerate().map(|(i, u)| (u, i)).collect();
+
+  let questions: Vec<_> = questions.into_iter().cloned().collect();
+  let question_lookup: HashMap<&Question, usize> =
+    questions.iter().enumerate().map(|(i, u)| (u, i)).collect();
+
+  let mut scores = vec![vec![0; questions.len()]; users.len()]; // [user][question]
+  let mut grand_scores = vec![0; users.len()];
+
+  let created = start.elapsed();
+  println!("Created users and questions in {}ms", created.as_millis());
+  println!("{} users", users.len());
+  println!("{} questions", questions.len());
+
+  let start = Instant::now();
+  let mut bitsets: Vec<_> = (0..questions.len())
+    .map(|_| vec![0u64; (users.len() + 63) / 64])
+    .collect();
+
+  for row in data.iter() {
+    let u_idx = user_lookup[&row.user];
+    let q_idx = question_lookup[&row.question];
+    bitsets[q_idx][u_idx / 64] |= 1 << (u_idx % 64);
+    scores[u_idx][q_idx] = row.score;
+    grand_scores[u_idx] += row.score;
+  }
+
+  let scores = scores;
+  let bitsets = bitsets;
+
+  let bitsets_elapsed = start.elapsed();
+  println!("Created scores in {}ms", bitsets_elapsed.as_millis());
+
+  let start = Instant::now();
+  let max = questions.len();
+  let (max_set, max_value) = questions[0..(max - k + 1)]
+    .par_iter()
+    .enumerate()
+    .map(|(start_idx, _)| {
+      let mut working_questions: Vec<_> = (start_idx..(start_idx + k)).collect();
+      let mut working_bitsets = vec![vec![0; (users.len() + 63) / 64]; k];
+      let mut actual_scores = vec![0.0; users.len()];
+      let mut predicted_scores = vec![0.0; users.len()];
+
+      let calc_question =
+        |working_questions: &[usize], working_bitsets: &mut [Vec<u64>], idx: usize| {
+          if idx == 0 {
+            return;
+          }
+
+          let (start, end) = working_bitsets.split_at_mut(idx);
+          let prev = start.last().unwrap();
+          let next = end.first_mut().unwrap();
+          intersect_into(next, prev, &bitsets[working_questions[idx]]);
+        };
+      // clone base bitset
+      working_bitsets[0].clone_from(&bitsets[working_questions[0]]);
+      for idx in 1..k {
+        calc_question(&mut working_questions, &mut working_bitsets, idx);
+      }
+
+      let calc_correlation = |actual_scores: &mut [f64],
+                              predicted_scores: &mut [f64],
+                              working_questions: &[usize],
+                              bitset: &[u64]|
+       -> f64 {
+        let mut count = 0usize;
+        for ((user_idx, actual_score), predicted_score) in iterate_bits(bitset)
+          .zip(actual_scores.iter_mut())
+          .zip(predicted_scores.iter_mut())
+        {
+          let user_row = &scores[user_idx];
+          *actual_score = grand_scores[user_idx] as f64;
+          *predicted_score = working_questions
+            .iter()
+            .map(|question_idx| user_row[*question_idx])
+            .sum::<u32>() as f64;
+          count += 1;
+        }
+        utils::correlation(&predicted_scores[..count], &actual_scores[..count])
+      };
+
+      // calc initial scores
+      let mut max_correlation = calc_correlation(
+        &mut actual_scores,
+        &mut predicted_scores,
+        &mut working_questions,
+        working_bitsets.last().unwrap(),
+      );
+      let mut max_questions = working_questions.clone();
+
+      loop {
+        // get next question set
+        // searching from the end, find first element that can increment
+        let start = working_questions
+          .iter()
+          .enumerate()
+          .skip(1)
+          .rposition(|(offset, q_idx)| *q_idx + k - offset < questions.len());
+
+        match start {
+          // if not found, break
+          None => break,
+          // otherwise increment found element, and set following elements to be sequential
+          Some(start_idx) => {
+            // start_idx is off by one due to skipping first field
+            let start_idx = start_idx + 1;
+            let start_value = working_questions[start_idx] + 1;
+            for idx in start_idx..working_questions.len() {
+              working_questions[idx] = start_value + idx - start_idx;
+              calc_question(&mut working_questions, &mut working_bitsets, idx);
+            }
+          }
+        }
+
+        // calc correlation
+        let correlation = calc_correlation(
+          &mut actual_scores,
+          &mut predicted_scores,
+          &mut working_questions,
+          working_bitsets.last().unwrap(),
+        );
+
+        // compare against
+        if correlation >= max_correlation {
+          max_correlation = correlation;
+          max_questions = working_questions.clone();
+        }
+      }
+
+      (max_questions, max_correlation)
+    })
+    .max_by(|(_, a), (_, b)| a.total_cmp(b))
+    .unwrap();
+  let run = start.elapsed();
+
+  println!("Finished processing in {}ms", run.as_millis());
+  println!("{max_set:?} {max_value}");
+  for question in max_set {
+    println!("{:?}", questions[question]);
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use std::{fs::File, io::BufReader, path::Path};
 
 pub mod inner;
 pub mod outer;
-mod utils;
+pub mod utils;
 
 pub use inner::{inner_names, CorrSetInner};
 pub use outer::{outer_names, CorrSetOuter};


### PR DESCRIPTION
# Summary
One potential improvement is being able to reuse work between combinations. Currently, the design uses itertool's `combinations` to generate independent combinations of of questions. If we instead manually create the combinations we can calculate and reuse the bits masks for the earlier sub-set of the combination.

This strategy is implemented in this PR as a separate binary for several reasons:
* Uses a unified structure rather than the inner/outer dichotomy your binary has
* Uses a plain vec of u64 for it's bit mask due to requiring the use of `BitOr` functionality rather than `BitOrAssign` and didn't want to modify your library
  * Even with this (presumably) regression in performance of calculation intersections, the reuse of bitmasks gives a performance benefit.

As such you probably will want to more smoothly integrate the ideas here more natively into your repo. This PR mainly serves as an example implementation.

The next few sections give an overview of my implementation. If you already have the jist of it and all that is unnecessary, I have included performance stats on my machine (Windows, 8 core 16 thread, 5800x3d) near the end of this comment.

# Manual Combination Calculation
Given a list of N unique elements, we can iterate through all combinations of K elements. The combinations will be represented as a sorted list of element indices. With this scheme we can determine the smallest and largest such combinations, telegraphically speaking (ie. [0, 1, 2, ... , k-1] and [n-k, ... , n-3, n-2, n-1]). To begin the iteration, we start with the smallest combination. Then for any given combination, to get the next combination, we iterate backwards through the combination to find the last (furthest right) element index that is not at the max value for its position. If there isn't one, we have the largest combination and we are done, otherwise we increase the found element index by one and each subsequent index (moving right) is one larger than the one we just set.

Example with N=5 K=3:
* [0, 1, 2] - Smallest combination (max is [3, 4, 5] and is what we will compare against and stop at)
* [0, 1, 3] - We check 2 and see that is it not at that position's max of 5 and increment it
* [0, 1, 4]
* [0, 1, 5]
* [0, 2, 3] - After iterating a few times, we arrive at the max of 5 and have to increment the second position and set the last one to 3
* [0, 2, 4]
* [0, 2, 5]
* [0, 3, 4]
* [1, 2, 3] - Now that both the second and last position are that their max, we increment the first position and reset the other two
* [1, 2, 4]
* [1, 2, 5]
* [1, 3, 4]
* [1, 3, 5]
* [2, 3, 4]
* [2, 3, 5]
* [3, 4, 5] - All positions are at their max so we are done iterating

# Re-using Bit masks
This method of iterations allows us to keep a list of bitmasks the correspond with the intersection of a prefix of the combination. So the first bitmask in our list corresponds to the bitmask for the first question in the combination. The second bitmask is the intersection of the first two questions, and so on. When we iterate through the combinations we can update only the bitmasks that are associated with the positions that change. This reduces the number of intersection calculations per combination at the cost of more memory used and touched overall. Since we are storing these longer, we need to be able to get the intersection of two bitmasks and store them into a third, this will require modifying the bitmask library to support this.

# Parallel Iteration
Due to the large amount of sequential state, it is difficult to iterate in parallel over individual or bulked combinations. Instead we iterate over the first position of the combination, where the iteration is passed the first position and runs through all of the combinations with that value in that position. This reduces the need for passing buffers between iterations and I have skipped that optimization in my example implementation.

# Performance statistics
These are some informal statistics after using hyperfine to run each configuration 5 times after a release build. The medium file is the ones provided in the repo, while the large file was generated with the suggested  `cargo run --release --bin gen-data -- 60000 200 0.2 > data/data-large.json` command.

For the faster test cases, most of the time is taken up by the reading and parsing of the file (my implementation prints that statistic and it seems to take 224ms for the medium file and 1820ms for the large file).

| File   | Depth | batched + alloc time | reuse_bin time |
|--------|-------|----------------------|----------------|
| Medium | 2     | 304.3 ms             | 315.5 ms       |
| Medium | 3     | 332.3 ms             | 342.2 ms       |
| Medium | 5     | 4.452 s              | 2.095 s        |
| Large  | 2     | 2.584 s              | 2.661 s        |
| Large  | 3     | 3.551 s              | 3.824 s        |
| Large  | 5     | 449.479 s            | 229.557 s      |

# Other considerations
Itertools::combinations creates a Vec for each combination single threadedly, while can be a bottle neck. So the fact that we manually iterate over the combinations in each iteration is in of itself a boon as we don't allocate a Vec and the determination of the combination indices is also now parallel.

As mentioned previously, my implementation uses non-SIMD based bitsets since it was too much effort for me to modify your library in place or to extract the needed portion out. It stands to reason that a SIMD implementation of `intersect_into` would
provide even more benefit.