### PR TITLE
More performance improvements

### DIFF
--- a/src/fused.rs
+++ b/src/fused.rs
@@ -38,10 +38,10 @@ impl<'a, 'b> QuestionCombinations<'a, 'b> {
       .map(|j| QuestionIdx::from_usize(root.index() + j))
       .collect_vec();
 
-    let mut users = vec![inner.q_to_score[qs[0]].1.clone()];
+    let mut users = vec![inner.bitset[qs[0]].clone()];
     for q in &qs[1..k] {
       let mut last = users.last().unwrap().clone();
-      last.intersect(&inner.q_to_score[*q].1);
+      last.intersect(&inner.bitset[*q]);
       users.push(last);
     }
 
@@ -79,13 +79,13 @@ impl<'a, 'b> Iterator for QuestionCombinations<'a, 'b> {
       self.qs[i] += 1;
       let [cur, prev] = unsafe { self.users.get_many_unchecked_mut([i, i - 1]) };
       cur.clone_from(prev);
-      cur.intersect(&self.inner.q_to_score[self.qs[i]].1);
+      cur.intersect(&self.inner.bitset[self.qs[i]]);
 
       for j in (i + 1)..self.k {
         self.qs[j] = self.qs[j - 1] + 1;
         let [cur, prev] = unsafe { self.users.get_many_unchecked_mut([j, j - 1]) };
         cur.clone_from(prev);
-        cur.intersect(&self.inner.q_to_score[self.qs[j]].1);
+        cur.intersect(&self.inner.bitset[self.qs[j]]);
       }
     }
 


### PR DESCRIPTION
The following performance improvements are in this PR and one to your indexical repo:
* When iterating over a SIMD bitset, we can check that the entire SIMD register is non-zero.
    * More detail in https://github.com/willcrichton/indexical/pull/2
* Separating and transposing the raw scores to allow better lookup/cache behavior
* Manual "iteration" of QuestionCombinations to allow for removing of QuestionCombinations cloning
    * I don't think this can be done with normal iterators due requiring lending iterators. The manual iteration is a bit messy, but does get some amount of performance.

On a large dataset with k = 5 I get the following improvements:
| Change           | Runtime (s)| Total Reduction |
|------------------|---------|-----------------|
| Base             | 264.923 | 00%             |
| Simd Iter Skip 0 | 202.173 | 24%             |
| Scores           | 193.053 | 27%             |
| Manual Iter      | 178.496 | 32%             |

I have testing another change that replaces the clone and BitOrAssign with a bit or and separate assignment. This removes the need for the clone and reduces the runtime by a further 10s on my machine. This does require coordination between this repo and the indexical one, so it was left off of these current PRs. Let me know if that course of action sounds worth pursuing.